### PR TITLE
Refactor and use removal before applying releases

### DIFF
--- a/src/Squirrel/UpdateManager.ApplyReleases.cs
+++ b/src/Squirrel/UpdateManager.ApplyReleases.cs
@@ -46,7 +46,7 @@ namespace Squirrel
                 }
                 catch (Exception ex)
                 {
-                    this.Log().WarnException("Failed to remove old folders, continuing anyways", ex);
+                    this.Log().WarnException("Failed to remove old folders.", ex);
                 }
 
                 // Progress range: 00 -> 40

--- a/src/Squirrel/UpdateManager.ApplyReleases.cs
+++ b/src/Squirrel/UpdateManager.ApplyReleases.cs
@@ -39,10 +39,8 @@ namespace Squirrel
                 // Try to remove older versions before applying releases
                 try
                 {
-                    var currentVersion = updateInfo.CurrentlyInstalledVersion != null ?
-                        updateInfo.CurrentlyInstalledVersion.Version : null;
-                    // remove all versions except the current one
-                    await removeOldVersionFolders(new SemanticVersion[] { currentVersion });
+                    // Remove all versions except the current one
+                    await removeOldVersionFolders(new SemanticVersion[] { updateInfo.CurrentlyInstalledVersion?.Version });
                 }
                 catch (Exception ex)
                 {
@@ -110,10 +108,8 @@ namespace Squirrel
                 progress(98);
 
                 try {
-                    var currentVersion = updateInfo.CurrentlyInstalledVersion != null ?
-                        updateInfo.CurrentlyInstalledVersion.Version : null;
-
-                    await cleanDeadVersions(currentVersion, newVersion);
+                    // This call removes older packages from the package folder. newVersion is the only package kept there.
+                    cleanDeadVersions(newVersion);
                 } catch (Exception ex) {
                     this.Log().WarnException("Failed to clean dead versions, continuing anyways", ex);
                 }
@@ -675,14 +671,9 @@ namespace Squirrel
             // directory are "dead" (i.e. already uninstalled, but not deleted), and
             // we blow them away. This is to make sure that we don't attempt to run
             // an uninstaller on an already-uninstalled version.
-            async Task cleanDeadVersions(SemanticVersion currentVersion, SemanticVersion newVersion, bool forceUninstall = false)
+            void cleanDeadVersions(SemanticVersion newVersion)
             {
                 if (newVersion == null) return;
-
-                var versionsToSave = new SemanticVersion[] { currentVersion, newVersion };
-
-                // Let's remove all folders with versions which are not current and new.
-                await removeOldVersionFolders(versionsToSave, forceUninstall);
 
                 // Clean up the packages directory too
                 var releasesFile = Utility.LocalReleaseFileForAppDir(rootAppDirectory);

--- a/src/Squirrel/UpdateManager.ApplyReleases.cs
+++ b/src/Squirrel/UpdateManager.ApplyReleases.cs
@@ -41,7 +41,7 @@ namespace Squirrel
                 {
                     var currentVersion = updateInfo.CurrentlyInstalledVersion != null ?
                         updateInfo.CurrentlyInstalledVersion.Version : null;
-                    // We remove all versions but current
+                    // remove all versions except the current one
                     await removeOldVersionFolders(new SemanticVersion[] { currentVersion });
                 }
                 catch (Exception ex)

--- a/src/Squirrel/UpdateManager.ApplyReleases.cs
+++ b/src/Squirrel/UpdateManager.ApplyReleases.cs
@@ -41,7 +41,7 @@ namespace Squirrel
                 {
                     var currentVersion = updateInfo.CurrentlyInstalledVersion != null ?
                         updateInfo.CurrentlyInstalledVersion.Version : null;
-
+                    // We remove all versions but current
                     await removeOldVersionFolders(new SemanticVersion[] { currentVersion });
                 }
                 catch (Exception ex)
@@ -584,12 +584,12 @@ namespace Squirrel
             /// <summary>
             /// Remove folders for older versions.
             /// </summary>
-            /// <param name="versionsToSave">Versions that should not be deleted</param>
+            /// <param name="versionsToKeep">Versions that should not be deleted</param>
             /// <param name="forceUninstall">Legacy argument</param>
             /// <returns></returns>
-            async Task removeOldVersionFolders(SemanticVersion[] versionsToSave, bool forceUninstall = false)
+            async Task removeOldVersionFolders(SemanticVersion[] versionsToKeep, bool forceUninstall = false)
             {
-                if(versionsToSave.Any(x => x == null))
+                if(versionsToKeep.Any(x => x == null))
                 {
                     return;
                 }
@@ -600,7 +600,7 @@ namespace Squirrel
                 // Get all directories which are not equal to any of the folders for versions from versionsToSave
                 var toCleanup = di.GetDirectories()
                     .Where(x => x.Name.ToLowerInvariant().Contains("app-"))
-                    .Where(x => versionsToSave.All(v => getDirectoryForRelease(v).Name != x.Name))
+                    .Where(x => versionsToKeep.All(v => getDirectoryForRelease(v).Name != x.Name))
                     .Where(x => !isAppFolderDead(x.FullName));
 
                 // Make all versions, which are scheduled to be deleted, dead
@@ -635,7 +635,7 @@ namespace Squirrel
                 // Include dead folders in folders to :fire:
                 toCleanup = di.GetDirectories()
                     .Where(x => x.Name.ToLowerInvariant().Contains("app-"))
-                    .Where(x => versionsToSave.All(v => getDirectoryForRelease(v).Name != x.Name));
+                    .Where(x => versionsToKeep.All(v => getDirectoryForRelease(v).Name != x.Name));
 
                 // Get the current process list in an attempt to not burn 
                 // directories which have running processes


### PR DESCRIPTION
Optimize the update process by removing the oldest version before application of patches